### PR TITLE
Add release content type and related post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- ## [Unreleased] -->
 
+## [0.3.0] - 2019-10-13
+
+### Added
+
+- A `release` content type for sharing release updates, including the latest Indigo release notes.
+- A `mainSections` parameter in the config.toml file includes `post` and `release` sections.
+
 ## [0.2.0] - 2019-10-13
 
 ### Added
@@ -24,7 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - The initial Hugo site source, including submodules for the public site build and the latest Indigo theme
 
-<!-- [unreleased]: https://github.com/AngeloStavrow/hello-indigo/compare/v0.2.0...HEAD -->
+<!-- [unreleased]: https://github.com/AngeloStavrow/hello-indigo/compare/v0.3.0...HEAD -->
 
+[0.3.0]: https://github.com/AngeloStavrow/hello-indigo/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/AngeloStavrow/hello-indigo/compare/v0.1...v0.2.0
 [0.1.0]: https://github.com/AngeloStavrow/hello-indigo/releases/tag/v0.1

--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,7 @@ theme = "indigo"
   Biography = "A short description, a few sentences describing the author. Set the 'ShowBio' parameter to false to hide this."
   ShowBio = true
   PermalinkText = "🔗"
+  mainSections = ["post", "release"]
 
   # Contact/social-network identifiers for social icons
   EmailAddress = "email.address@example.com"

--- a/content/post/custom-css-support.md
+++ b/content/post/custom-css-support.md
@@ -1,0 +1,21 @@
+---
+title: "Custom CSS support"
+date: 2019-08-31T20:00:00-04:00
+draft: false
+categories: ["features"]
+tags: ["styling", "customization"]
+---
+
+With the [release of v1.2.0], Indigo now supports custom CSS!
+
+<!--more-->
+
+To do so, add a file called `custom.css` in your site's `/static/css` folder (you'll have to create that folder if it doesn't already exist). In that file, you can add whatever custom styles you'd like, and they'll override any built-in styles.
+
+You can see an example of this [here], which uses a custom palette as well as additional styling on [the updates page]; Angelo has written about the motivation for custom CSS in [this blog post] and shares his own [custom.css file].
+
+[release of v1.2.0]: /release/indigo-v1-2-0-released/
+[here]: https://angelostavrow.com/
+[the updates page]: https://angelostavrow.com/updates/
+[this blog post]: https://angelostavrow.com/post/indigo-theme-updates/
+[custom.css file]: https://github.com/AngeloStavrow/angelostavrow.com/blob/master/static/css/custom.css

--- a/content/post/featured-typefaces.md
+++ b/content/post/featured-typefaces.md
@@ -3,7 +3,7 @@ title: "Featured Typefaces"
 date: 2018-10-01T08:30:00-04:00
 draft: false
 categories: ["features"]
-tags: ["typography"]
+tags: ["typography", "styling"]
 ---
 
 Indigo uses a combination of three beautiful typefaces to render your words.

--- a/content/release/indigo-v1-2-0-released.md
+++ b/content/release/indigo-v1-2-0-released.md
@@ -1,0 +1,21 @@
+---
+title: "Indigo v1.2.0 released"
+date: 2019-08-31T20:00:00-04:00
+draft: false
+categories: ["releases"]
+tags: ["indigo"]
+---
+
+Indigo [v1.2.0] is a minor release that adds support for custom CSS.
+
+<!--more-->
+
+Read more about custom CSS support [here]. From the [changelog]:
+
+## Added
+
+- You can now import custom CSS from `<YOUR_HUGO_SITE>/static/css/custom.css`.
+
+[v1.2.0]: https://github.com/AngeloStavrow/indigo/releases/tag/v1.2.0
+[here]: /post/custom-css-support/
+[changelog]: https://github.com/AngeloStavrow/indigo/blob/master/CHANGELOG.md#120

--- a/content/release/indigo-v1-3-0-released.md
+++ b/content/release/indigo-v1-3-0-released.md
@@ -1,0 +1,35 @@
+---
+title: "Indigo v1.3.0 released"
+date: 2019-09-30T09:00:00-04:00
+draft: false
+categories: ["releases"]
+tags: ["indigo"]
+---
+
+Indigo [v1.3.0] is a minor release that brings Indigo into better compliance with Hugo theme guidelines.
+
+<!--more-->
+
+From the [changelog]:
+
+## Added
+
+- Adds a `mainSection` configuration parameter to set preferred content name.
+
+## Changed
+
+- Updated **CONTRIBUTING.md** to reflect new contributions process.
+- Bumped the minimum Hugo version requirement to 0.58 to account for breaking changes to list pages.
+
+## Fixed
+
+- As part of an audit of the theme's code:
+  - Removed forward slashes (`/`) in URLs for better compatibility with sites that don't live at a domain root.
+  - Fixed the location from which the theme's fonts are loaded.
+
+## Removed
+
+- GitHub issue and pull request templates removed from the repo.
+
+[v1.3.0]: https://github.com/AngeloStavrow/indigo/releases/tag/v1.3.0
+[changelog]: https://github.com/AngeloStavrow/indigo/blob/master/CHANGELOG.md#130

--- a/content/release/indigo-v1-3-1-released.md
+++ b/content/release/indigo-v1-3-1-released.md
@@ -1,0 +1,20 @@
+---
+title: "Indigo v1.3.1 released"
+date: 2019-10-03T09:30:00-04:00
+draft: false
+categories: ["releases"]
+tags: ["indigo"]
+---
+
+Indigo [v1.3.1] is a patch release that fixes a list bug.
+
+<!--more-->
+
+From the [changelog]:
+
+## Fixed
+
+- Taxonomy-based lists (e.g., lists of tags or categories) now only show posts within the selected taxonomy.
+
+[v1.3.1]: https://github.com/AngeloStavrow/indigo/releases/tag/v1.3.1
+[changelog]: https://github.com/AngeloStavrow/indigo/blob/master/CHANGELOG.md#131


### PR DESCRIPTION
This pull request implements and closes #2 by adding a `release` content type and includes a few of the latest `release` updates, as well as a `post` update on custom CSS support.